### PR TITLE
[INSTORE-670, INSTORE-662, INSTORE-661, INSTORE-664] Several fixups

### DIFF
--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -131,7 +131,7 @@ class BluetoothSerial : CordovaPlugin() {
 
     private fun send(args: CordovaArgs, callbackContext: CallbackContext) {
         if (BluetoothSerialService.state != STATE_CONNECTED) {
-            Log.d(TAG, "Attempt send but not connected")
+            Log.d(TAG, "Attempted send but not connected")
             callbackContext.error("Not connected")
         } else {
             try {

--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -98,6 +98,17 @@ class BluetoothSerial : CordovaPlugin() {
         return validAction
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        BluetoothSerialService.stop()
+    }
+
+    private fun enableBluetoothIfNecessary() {
+        if (!bluetoothAdapter.isEnabled) {
+            bluetoothAdapter.enable()
+        }
+    }
+
     private fun listen(callbackContext: CallbackContext) {
         if (BluetoothSerialService.state == STATE_CONNECTED) {
             callbackContext.error("Already connected")
@@ -109,23 +120,6 @@ class BluetoothSerial : CordovaPlugin() {
                 callbackContext.error(e.toString())
             }
         }
-    }
-
-    private fun enableBluetoothIfNecessary() {
-        if (!bluetoothAdapter.isEnabled) {
-            bluetoothAdapter.enable()
-        }
-    }
-
-    private fun keepCallbackAndSendNoResult(callbackContext: CallbackContext) {
-        val result = PluginResult(PluginResult.Status.NO_RESULT)
-        result.keepCallback = true
-        callbackContext.sendPluginResult(result)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        BluetoothSerialService.stop()
     }
 
     @Throws(JSONException::class)
@@ -141,17 +135,23 @@ class BluetoothSerial : CordovaPlugin() {
     }
 
     private fun notifyConnectionLost() {
-        keepCallbackAndSendResult()
+        keepCallbackAndSendResult(closeCallback)
     }
 
     private fun notifyConnectionSuccess() {
-        keepCallbackAndSendResult()
+        keepCallbackAndSendResult(connectCallback)
     }
 
-    private fun keepCallbackAndSendResult() {
+    private fun keepCallbackAndSendResult(callbackContext: CallbackContext) {
         val result = PluginResult(PluginResult.Status.OK)
         result.keepCallback = true
-        connectCallback?.sendPluginResult(result)
+        callbackContext.sendPluginResult(result)
+    }
+
+    private fun keepCallbackAndSendNoResult(callbackContext: CallbackContext) {
+        val result = PluginResult(PluginResult.Status.NO_RESULT)
+        result.keepCallback = true
+        callbackContext.sendPluginResult(result)
     }
 
     private fun sendRawDataToSubscriber(data: ByteArray?) {

--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -42,7 +42,7 @@ class BluetoothSerial : CordovaPlugin() {
                 connect(args, callbackContext)
             }
             DISCONNECT -> {
-                disconnect()
+                disconnect(callbackContext)
             }
             SEND -> {
                 send(args, callbackContext)

--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -142,10 +142,10 @@ class BluetoothSerial : CordovaPlugin() {
         keepCallbackAndSendResult(connectCallback)
     }
 
-    private fun keepCallbackAndSendResult(callbackContext: CallbackContext) {
+    private fun keepCallbackAndSendResult(callbackContext: CallbackContext?) {
         val result = PluginResult(PluginResult.Status.OK)
         result.keepCallback = true
-        callbackContext.sendPluginResult(result)
+        callbackContext?.sendPluginResult(result)
     }
 
     private fun keepCallbackAndSendNoResult(callbackContext: CallbackContext) {

--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -26,9 +26,15 @@ class BluetoothSerial : CordovaPlugin() {
     override fun execute(action: String, args: CordovaArgs, callbackContext: CallbackContext): Boolean {
         LOG.d(TAG, "action = $action")
         var validAction = true
+
+        try {
+            enableBluetoothIfNecessary()
+        } catch (e: Exception) {
+            Log.e(TAG, "Unable to enable bluetooth: $e")
+        }
+
         when (action) {
             CONNECT -> {
-                enableBluetoothIfNecessary()
                 connect(args, callbackContext)
             }
             DISCONNECT -> {
@@ -96,7 +102,6 @@ class BluetoothSerial : CordovaPlugin() {
         if (BluetoothSerialService.state == STATE_CONNECTED) {
             callbackContext.error("Already connected")
         } else {
-            enableBluetoothIfNecessary()
             try {
                 BluetoothSerialService.start()
                 callbackContext.success()

--- a/src/android/com/megster/cordova/BluetoothSerial.kt
+++ b/src/android/com/megster/cordova/BluetoothSerial.kt
@@ -120,7 +120,7 @@ class BluetoothSerial : CordovaPlugin() {
                 BluetoothSerialService.connect(device)
                 callbackContext.success()
             } else {
-                Log.e(TAG, "Could not connect to $macAddress: $e")
+                Log.d(TAG, "Could not connect to $macAddress")
                 callbackContext.error("Could not connect to $macAddress")
             }
         } catch (e: Exception) {
@@ -145,7 +145,7 @@ class BluetoothSerial : CordovaPlugin() {
         }
     }
 
-    private fun disconnect() {
+    private fun disconnect(callbackContext: CallbackContext) {
         try {
             BluetoothSerialService.stop()
             callbackContext.success()


### PR DESCRIPTION
[INSTORE-670](https://fivestars.atlassian.net/browse/INSTORE-670)
Should enable bluetooth if not enabled when retrieving MAC Address

[INSTORE-662](https://fivestars.atlassian.net/browse/INSTORE-662)
Calling send when *not* connected does not invoke error callback

[INSTORE-661](https://fivestars.atlassian.net/browse/INSTORE-661)
Calls onConnect callback after calling disconnect instead of onClose callback

[INSTORE-664](https://fivestars.atlassian.net/browse/INSTORE-664)
On occasion it will hard fail resulting in neither the success nor error callback being invoked